### PR TITLE
Update ingress-srv.yaml

### DIFF
--- a/K8S/ingress-srv.yaml
+++ b/K8S/ingress-srv.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: ingress-srv
   annotations:
-    kubernetes.io/ingress.class: nginx
+    ingressClassName: nginx
     nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
   rules:


### PR DESCRIPTION
annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead