### PR TITLE
Update platforms-np-srv.yaml

### DIFF
--- a/K8S/platforms-np-srv.yaml
+++ b/K8S/platforms-np-srv.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - name: platformservice
       protocol: TCP
-      port: 80
-      targetPort: 80
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
"socket hang up" in Postman.
Starting with .NET 8, default .NET Core port changed from 80 to 8080.